### PR TITLE
docs(forms): fix typo

### DIFF
--- a/public/docs/ts/latest/guide/forms.jade
+++ b/public/docs/ts/latest/guide/forms.jade
@@ -268,7 +268,7 @@ figure.image-display
   :marked
     We appended a diagnostic interpolation after the input tag
     so we can see what we're doing.
-    We left ourselves a note to throw it way when we're done.
+    We left ourselves a note to throw it away when we're done.
 
 :marked
   Focus on the binding syntax: `[(ngModel)]="..."`.


### PR DESCRIPTION
Change "way" to "away" in the following context: "throw it away".